### PR TITLE
Removed return statements from string.rb

### DIFF
--- a/string.rb
+++ b/string.rb
@@ -1,13 +1,11 @@
-
-
 class String
 
   def uiimage
-    return UIImage.imageNamed(self)
+    UIImage.imageNamed(self)
   end
 
   def uifont(size=UIFont.systemFontSize)
-    return UIFont.fontWithName(self, size:size)
+    UIFont.fontWithName(self, size:size)
   end
 
 end


### PR DESCRIPTION
Since the end line of every `def` is returned automatically, it isn't needed.
