### PR TITLE
Add support for alignment rect setting in UIImage helper

### DIFF
--- a/lib/sugarcube/uiimage.rb
+++ b/lib/sugarcube/uiimage.rb
@@ -190,4 +190,11 @@ class UIImage
     resizableImageWithCapInsets(insets, resizingMode:UIImageResizingModeStretch)
   end
 
+  ##|
+  ##|  imageWithAlignmentRectInsets
+  ##|
+  def alignment_rect(insets=UIEdgeInsetsZero)
+    imageWithAlignmentRectInsets(insets)
+  end
+
 end


### PR DESCRIPTION
Here's a small patch that adds alignment_rect to the UIImage helpers. I just patched this in without testing it since I am pretty new to RubyMotion and wasn't sure how to set up a test rig, but it should be straightforward to check my syntax I hope. Thanks!
