### PR TITLE
add inanimate option

### DIFF
--- a/lib/sugarcube/uiview.rb
+++ b/lib/sugarcube/uiview.rb
@@ -68,23 +68,28 @@ class UIView
       duration = options[:duration] || 0.3
     end
 
-    after_animations = options[:after]
-    if after_animations
-      if after_animations.arity == 0
-        after_adjusted = proc { |finished| after_animations.call }
+    unless options[:inanimate]
+      after_animations = options[:after]
+      if after_animations
+        if after_animations.arity == 0
+          after_adjusted = proc { |finished| after_animations.call }
+        else
+          after_adjusted = proc { |finished| after_animations.call(finished) }
+        end
       else
-        after_adjusted = proc { |finished| after_animations.call(finished) }
+        after_adjusted = nil
       end
-    else
-      after_adjusted = nil
-    end
 
-    UIView.animateWithDuration( duration,
+      UIView.animateWithDuration( duration,
                          delay: options[:delay] || 0,
                        options: options[:options] || UIViewAnimationOptionCurveEaseInOut,
                     animations: proc,
                     completion: after_adjusted
                               )
+    else
+      proc.call
+    end
+
     nil
   end
 


### PR DESCRIPTION
I added :inanimate option to UIView.animate.

It's just an idea.
I think there is a more better way.

I want to move a view as rotating.
With :inanimate option, like this.

```
    animate {
      self.slide(:right, size:50, inanimate:true)
      self.rotate_to(angle:90.degrees, inanimate:true)
    }
```

But nesting is annoying and require reverse ordering.

```
    animate(after: Proc.new {
      animate(after: Proc.new {
        animate(after: Proc.new {
          animate {
            self.slide(:up, size:50, inanimate:true)
            self.rotate_to(angle:0.degrees, inanimate:true)
          }
        }) {
          self.slide(:left, size:50, inanimate:true)
          self.rotate_to(angle:270.degrees, inanimate:true)
        }
      }) {
        self.slide(:down, size:50, inanimate:true)
        self.rotate_to(angle:180.degrees, inanimate:true)
      }
    }) {
      self.slide(:right, size:50, inanimate:true)
      self.rotate_to(angle:90.degrees, inanimate:true)
    }
```

I make a sample project.
https://github.com/katsuyoshi/sugarcube-animation-test
