### PR TITLE
fix a behavior of the cancel with two buttons.

### DIFF
--- a/lib/sugarcube/uialertview.rb
+++ b/lib/sugarcube/uialertview.rb
@@ -61,8 +61,8 @@ module SugarCube
     attr_accessor :on_success
 
     def alertView(alert, didDismissWithButtonIndex:index)
-      if index == alert.cancelButtonIndex && on_cancel
-        on_cancel.call
+      if index == alert.cancelButtonIndex
+        on_cancel.call if on_cancel
       elsif on_success
         if on_success.arity == 0
           on_success.call


### PR DESCRIPTION
I call this style alert view.
It calls a block even if the "Nevermind" was selected.

``` ruby
UIAlertView.alert("This is happening, OK?", buttons: ["Nevermind", "OK"],
  message: "Don't worry, it'll be fine.") {
  self.happened!
}
```

I guess this fix is a right way although I have not tested other styles well.
