### PR TITLE
reuse NSDataDetector object to save memory

### DIFF
--- a/lib/sugarcube/date_parser.rb
+++ b/lib/sugarcube/date_parser.rb
@@ -37,9 +37,8 @@ module SugarCube
 
     private
     def self.detect(date_string)
-      error = Pointer.new(:object)
-      detector = NSDataDetector.dataDetectorWithTypes(NSTextCheckingTypeDate, error:error)
-      matches = detector.matchesInString(date_string, options:0, range:NSMakeRange(0, date_string.length))
+      @@detector ||= NSDataDetector.dataDetectorWithTypes(NSTextCheckingTypeDate, error:Pointer.new(:object))
+      matches = @@detector.matchesInString(date_string, options:0, range:NSMakeRange(0, date_string.length))
     end
   end
 end


### PR DESCRIPTION
We don't need to create NSDataDetector object each time when SugarCube::DateParser.parse_date called.
