### PR TITLE
Added a new gesture, on_press_begin, that fires once for a long press. on_press_begin works with UIActionSheets, which the on_press gesture has problems with.

### DIFF
--- a/lib/sugarcube-gestures/gestures.rb
+++ b/lib/sugarcube-gestures/gestures.rb
@@ -175,6 +175,29 @@ class UIView
     sugarcube_add_gesture(proc, recognizer)
   end
 
+  def on_press_begin(duration_or_options=nil, &proc)
+    duration = nil
+    taps = nil
+    fingers = nil
+
+    if duration_or_options
+      if duration_or_options.is_a? Hash
+        duration = duration_or_options[:duration] || duration
+        taps = duration_or_options[:taps] || taps
+        fingers = duration_or_options[:fingers] || fingers
+      else
+        duration = duration_or_options
+      end
+    end
+
+    recognizer = UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'sugarcube_handle_gesture_long_press_on_begin:')
+    recognizer.minimumPressDuration = duration if duration
+    recognizer.numberOfTapsRequired = taps if taps
+    recognizer.numberOfTouchesRequired = fingers if fingers
+    sugarcube_add_gesture(proc, recognizer)
+  end
+
+
 private
   def sugarcube_handle_gesture(recognizer)
     handler = @sugarcube_recognizers[recognizer]
@@ -182,6 +205,16 @@ private
       handler.call
     else
       handler.call(recognizer)
+    end
+  end
+  def sugarcube_handle_gesture_long_press_on_begin(recognizer)
+    if recognizer.state==UIGestureRecognizerStateBegan
+      handler = @sugarcube_recognizers[recognizer]
+      if handler.arity == 0
+        handler.call
+      else
+        handler.call(recognizer)
+      end
     end
   end
 


### PR DESCRIPTION
Opening a UIActionSheet from within a UILongPressGestureRecognizer (i.e. UIView.on_press { ... }) opens two UIActionSheets because the long press gesture is continuous and the gesture's state needs to be checked in the handler:

```
#this opens two identical action sheets when pressed (not good)
view.on_press do
  UIActionSheet.alert(nil, buttons: ['Cancel', "Delete", "Foo", "Bar"]) do |pressed|
      # ...
  end
end
```

This pull request adds a new gesture, `on_press_begin` that checks the state of the gesture before firing the handler:

```
#this opens one action sheet when pressed
view.on_press_begin do
  UIActionSheet.alert(nil, buttons: ['Cancel', "Delete", "Foo", "Bar"]) do |pressed|
      # ...
  end
end
```

based on:
http://stackoverflow.com/questions/13003384/uiactionsheet-called-twice
http://stackoverflow.com/questions/7907671/ios-uiactionsheet-presented-from-longpress-gesture-on-a-button-erroneously-requi
