### PR TITLE
add look_in file to color file set

### DIFF
--- a/lib/sugarcube-color.rb
+++ b/lib/sugarcube-color.rb
@@ -12,4 +12,7 @@ Motion::Project::App.setup do |app|
   Dir.glob(File.join(File.dirname(__FILE__), 'sugarcube-color/**/*.rb')).reverse.each do |file|
     app.files.insert(insert_point, file)
   end
+
+  look_in = File.join(File.dirname(__FILE__), 'sugarcube/look_in.rb')
+  app.files.insert(insert_point, look_in)
 end


### PR DESCRIPTION
When I use sugarcube-color only, I got an error.
Fix dependency.

```
gem 'sugarcube', :require => 'sugarcube-color'
```

```
:black.uicolor

symbol.rb:12:in `uicolor:': uninitialized constant Symbol::SugarCube (NameError)
=> #<NameError: uninitialized constant Symbol::SugarCube>
```
