### PR TITLE
Fix to avoid a cyclic reference in UIBarButtonItem.

### DIFF
--- a/lib/sugarcube-factories/uibarbuttonitem.rb
+++ b/lib/sugarcube-factories/uibarbuttonitem.rb
@@ -129,7 +129,7 @@ class UIBarButtonItem
   def set_target_and_action target, action
     self.target = target
     self.action = 'sugarcube_handle_action:'
-    @sugarcube_action = action
+    @sugarcube_action = action.respond_to?('weak!') ? action.weak! : action
   end
 
 


### PR DESCRIPTION
Push this controller on a navigation controller stack:

``` ruby
class LeakyController < UIViewController
  def viewWillAppear(animated)
    super
    self.navigationItem.leftBarButtonItem = UIBarButtonItem.done { go_back }
  end

  def go_back
    navigationController.popViewControllerAnimated(true)
  end

  def dealloc
    puts "LeakyController.dealloc"
  end
end
```

When `popViewControllerAnimated` is called, `LeakyController` will not be released if `UIBarButtonItem` has a strong ref on the action block.
