### PR TITLE
Added blink command to sugarcube-repl

### DIFF
--- a/lib/sugarcube-repl/object.rb
+++ b/lib/sugarcube-repl/object.rb
@@ -94,4 +94,7 @@ private
   def restore(*args)
     SugarCube::Adjust.restore(*args)
   end
+  def blink(*args)
+    SugarCube::Adjust.blink(*args)
+  end
 end

--- a/lib/sugarcube/adjust.rb
+++ b/lib/sugarcube/adjust.rb
@@ -244,6 +244,21 @@ module SugarCube
     end
     alias h shadow
 
+    def blink(color = UIColor.redColor)
+      raise "no view has been assigned to SugarCube::Adjust::adjust" unless $sugarcube_view
+
+      blinking_view = UIView.alloc.initWithFrame([[0,0],$sugarcube_view.frame.size])
+      blinking_view.backgroundColor = color
+      $sugarcube_view.addSubview(blinking_view)
+      UIView.animateWithDuration(0.2, animations: ->{ blinking_view.alpha = 0}, completion: ->(finished){
+        UIView.animateWithDuration(0.2, animations: ->{ blinking_view.alpha = 1}, completion: ->(finished){
+          UIView.animateWithDuration(0.2, animations: ->{ blinking_view.alpha = 0}, completion: ->(finished){
+            blinking_view.removeFromSuperview
+          })
+        })
+      })
+    end
+
     # @param item this can be a tree-like item (UIView, UIViewController,
     #     CALayer) or an integer, in which case it will select that window from
     #     UIApplication.sharedApplication.window.  Defalt is to display the


### PR DESCRIPTION
Adds a blink effect, by adding a subview to the front of the selected one and then animating its alpha property. After the animations end, the blinking_view is removed.

Didn't know how to add the animations to `sugarcube-osx/adjust.rb`
