### PR TITLE
Added a side parameter to tumble animation.

### DIFF
--- a/lib/sugarcube-animations/uiview.rb
+++ b/lib/sugarcube-animations/uiview.rb
@@ -417,16 +417,28 @@ class UIView
   # Moves the view off screen while slowly rotating it.
   #
   # Based on https://github.com/warrenm/AHAlertView/blob/master/AHAlertView/AHAlertView.m
-  def tumble(side=:left, options={}, more_options={}, &after)
+  def tumble(options={}, more_options={}, &after)
     if options.is_a? Numeric
       default_duration = options
       options = more_options
+      side = options[:side] || :left
+    elsif options.is_a? Symbol
+      side = options
+      options = more_options
+      default_duration = 0.3
     else
       default_duration = 0.3
+      side = options[:side] || :left
     end
 
-    angle = -Math::PI/4 if side == :left
-    angle = Math::PI/4 if side == :right
+    case side
+      when :left
+        angle = -Math::PI/4
+      when :right
+        angle = Math::PI/4
+      else
+        raise "Unknown direction #{side.inspect}"
+    end
 
     options[:duration] ||= default_duration
     options[:options] ||= UIViewAnimationOptionCurveEaseIn|UIViewAnimationOptionBeginFromCurrentState
@@ -455,7 +467,7 @@ class UIView
       height = window.frame.size.height - top
       offset = CGPoint.new(0, height * 1.5)
       offset = CGPointApplyAffineTransform(offset, self.transform)
-      self.transform = CGAffineTransformConcat(self.transform, CGAffineTransformMakeRotation(angle)
+      self.transform = CGAffineTransformConcat(self.transform, CGAffineTransformMakeRotation(angle))
       self.center = CGPointMake(self.center.x + offset.x, self.center.y + offset.y)
     end
   end
@@ -466,9 +478,24 @@ class UIView
   def tumble_in(options={}, &after)
     if options.is_a? Numeric
       default_duration = options
-      options = {}
+      options = more_options
+      side = options[:side] || :left
+    elsif options.is_a? Symbol
+      side = options
+      options = more_options
+      default_duration = 0.3
     else
       default_duration = 0.3
+      side = options[:side] || :left
+    end
+
+    case side
+      when :left
+        angle = -Math::PI/4
+      when :right
+        angle = Math::PI/4
+      else
+        raise "Unknown direction #{side.inspect}"
     end
 
     reset_transform = self.transform
@@ -483,7 +510,7 @@ class UIView
     height = window.frame.size.height - top
     offset = CGPoint.new(0, height * -1.5)
     offset = CGPointApplyAffineTransform(offset, self.transform)
-    self.transform = CGAffineTransformConcat(self.transform, CGAffineTransformMakeRotation(Math::PI/4))
+    self.transform = CGAffineTransformConcat(self.transform, CGAffineTransformMakeRotation(angle))
     self.center = CGPointMake(self.center.x + offset.x, self.center.y + offset.y)
 
     self.animate(options) do

--- a/spec/uiview_animation_tumble_spec.rb
+++ b/spec/uiview_animation_tumble_spec.rb
@@ -1,0 +1,75 @@
+describe "UIView animation methods" do
+  # the 'tumble' animation requires an app window to be present
+  tests UIViewController
+
+  before do
+    @view = UIView.alloc.initWithFrame([[1,2],[3,4]])
+    controller.view.addSubview(@view)
+  end
+
+  it 'should have a tumble animation' do
+    @done = false
+    @view.tumble
+    @view.center.y.should > UIScreen.mainScreen.bounds.size.height
+  end
+
+  it 'should have a tumble animation with duration' do
+    @done = false
+    @view.tumble(0.4) do |finished|
+      @done = finished ? :done : :unfinished
+    end
+    @view.center.y.should > UIScreen.mainScreen.bounds.size.height
+    wait 0.3 do
+      @done.should == false
+      wait 0.3 do
+        @done.should == :done
+      end
+    end
+  end
+
+  it 'should have a tumble animation with side as parameter' do
+    -> do
+      @view.tumble(:left)
+    end.should.not.raise
+  end
+
+  it 'should have a tumble animation with duration as option' do
+    @done = false
+    @view.tumble(duration: 0.4) do
+      @done = :done
+    end
+    @view.center.y.should > UIScreen.mainScreen.bounds.size.height
+    wait 0.3 do
+      @done.should == false
+      wait 0.2 do
+        @done.should == :done
+      end
+    end
+  end
+
+  it 'should have a tumble animation with side as option' do
+    @view.tumble(side: :left)
+    @view.center.y.should > UIScreen.mainScreen.bounds.size.height
+  end
+
+  it 'should have a tumble animation with invalid side option raising exception' do
+    -> do
+      @view.tumble(side: :this_is_silly)
+    end.should.raise
+  end
+
+  it 'should have a tumble animation with duration and options' do
+    @done = false
+    @view.tumble(0.4, options: UIViewAnimationOptionCurveEaseIn | UIViewAnimationOptionBeginFromCurrentState) do
+      @done = :done
+    end
+    @view.center.y.should > UIScreen.mainScreen.bounds.size.height
+    wait 0.3 do
+      @done.should == false
+      wait 0.2 do
+        @done.should == :done
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
I could change the angle setter to an if block and that way it would 'accept' invalid parameters, like `tumble(:up)`, and default to `:left`'s angle, but it would raise no errors about the wrong parameter.
