### PR TITLE
At string_with_format, fix the locale if the format is a Symbol.

### DIFF
--- a/lib/sugarcube-nsdate/nsdate.rb
+++ b/lib/sugarcube-nsdate/nsdate.rb
@@ -51,7 +51,10 @@ class NSDate
   # and
   # <http://www.unicode.org/reports/tr35/tr35-19.html#Date_Field_Symbol_Table>
   # for more information about date format strings.
-  def string_with_format(format, locale=NSLocale.currentLocale)
+  def string_with_format(format, options={})
+    locale = options[:locale] || NSLocale.currentLocale
+    timezone = options[:timezone] || NSTimeZone.defaultTimeZone
+    
     if format.is_a?(Symbol)
       formatters = SugarCubeFormats[format]
       raise "No format found for #{format.inspect}" unless formatters
@@ -60,7 +63,7 @@ class NSDate
       formatters.each do |formatter|
         case formatter
         when Symbol
-          retval << string_with_format(formatter.to_s, locale)
+          retval << string_with_format(formatter.to_s, locale:locale, timezone:timezone)
         when String
           retval << formatter
         end
@@ -71,6 +74,7 @@ class NSDate
                                                         locale:locale)
       date_formatter = NSDateFormatter.new
       date_formatter.setDateFormat(format_template)
+      date_formatter.setTimeZone(timezone)
       return date_formatter.stringFromDate(self)
     end
   end

--- a/spec/nsdate_spec.rb
+++ b/spec/nsdate_spec.rb
@@ -101,6 +101,11 @@ describe "NSDate" do
     @date.string_with_format(:iso8601).should == '2013-01-02 12:15:30.000'
   end
 
+  it "should have an NSDate#string_with_format method (:iso8601) and timezone" do
+    date = @date + @date.utc_offset
+    date.string_with_format(:iso8601, timezone:"UTC".nstimezone).should == '2013-01-02 12:15:30.000'
+  end
+
   it "should have an NSDate#string_with_format method (:ymd)" do
     @date.string_with_format(:ymd).should == '2013-01-02'
   end


### PR DESCRIPTION
If I set Region Format Japanese by Settings app, string_with_format(:iso8601) returns with Japanese style.
Maybe it should be a same value by all locales.

```
Bacon::Error: "2013年-01月-02日 12:15:30.000".==("2013-01-02 12:15:30.000") failed
```
