### PR TITLE
alias method for inverting a uiimage

### DIFF
--- a/lib/sugarcube-image/uiimage.rb
+++ b/lib/sugarcube-image/uiimage.rb
@@ -414,6 +414,18 @@ class UIImage
     return UIImage.imageWithCIImage(output, scale:self.scale, orientation:self.imageOrientation)
   end
 
+  # Invert the image
+  # @options - none
+  # 
+  # @example
+  #   image.inverted
+  # 
+  # similar to (image | CIFilter.color_invert).uiimage
+  def inverted(*args)
+    output = self.apply_filter(CIFilter.color_invert(*args))
+    return UIImage.imageWithCIImage(output, scale:self.scale, orientation:self.imageOrientation)
+  end
+  
   # Apply a gaussian filter
   # @options radius, default: 10
   #


### PR DESCRIPTION
adds `image.inverted` instead of what has to be done now `(image | CIFilter.color_invert).uiimage`
