### PR TITLE
Added MotionKit ids to sugarcube_to_s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg/
 .DS_Store
 /build/
 .idea/
+.repl_history

--- a/lib/ios/sugarcube-to_s/uiview.rb
+++ b/lib/ios/sugarcube-to_s/uiview.rb
@@ -1,11 +1,10 @@
 class UIView
 
   def sugarcube_to_s(options={})
-    if self.respond_to? :stylename and self.stylename
-      suffix = ' stylename: ' + self.stylename.inspect
-    else
-      suffix = ''
-    end
+    suffix = ''
+    suffix += " stylename: #{self.stylename.inspect}" if self.respond_to?(:stylename) && self.stylename
+    suffix += " motion_kit_id: #{self.motion_kit_id.inspect}" if self.respond_to?(:motion_kit_id) && self.motion_kit_id
+
     if options[:inner].is_a? Hash
       inner = ''
       options[:inner].each do |key, value|


### PR DESCRIPTION
```
(nil)? tree
  0: . UIWindow(#a951c60, [[0.0, 0.0], [320.0, 568.0]])
  1: `-- UIView(#a76e950, [[0.0, 0.0], [320.0, 568.0]])
  2:     +-- UILabel(#a76f800, [[149.5, 273.5], [21.0, 21.0]], text: "Hi!")
  3:     `-- MyOtherLabel(#a8dc260, [[0.0, 0.0], [0.0, 0.0]], text: nil) motion_kit_id: :my_other_label
```

I could change it to just `id: :my_other_label` if `motion_kit_id:` is too long, but I was following the Teacup example above it.
