### PR TITLE
Monkeypatch Kernel in development mode only

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    rake (10.1.0)
+    rake (10.3.2)
 
 PLATFORMS
   ruby

--- a/lib/sugarcube-repl.rb
+++ b/lib/sugarcube-repl.rb
@@ -6,18 +6,21 @@ end
 require 'sugarcube'
 
 Motion::Project::App.setup do |app|
-  # scans app.files until it finds app/ (the default)
-  # if found, it inserts just before those files, otherwise it will insert to
-  # the end of the list
-  insert_point = app.files.find_index { |file| file =~ /^(?:\.\/)?app\// } || 0
+  # This package is only available in development
+  app.development do
+    # scans app.files until it finds app/ (the default)
+    # if found, it inserts just before those files, otherwise it will insert to
+    # the end of the list
+    insert_point = app.files.find_index { |file| file =~ /^(?:\.\/)?app\// } || 0
 
-  Dir.glob(File.join(File.dirname(__FILE__), App.template.to_s, 'sugarcube-repl/**/*.rb')).reverse.each do |file|
-    app.files.insert(insert_point, file)
-  end
-  Dir.glob(File.join(File.dirname(__FILE__), 'cocoa/sugarcube-repl/**/*.rb')).reverse.each do |file|
-    app.files.insert(insert_point, file)
-  end
-  Dir.glob(File.join(File.dirname(__FILE__), 'all/sugarcube-repl/**/*.rb')).reverse.each do |file|
-    app.files.insert(insert_point, file)
+    Dir.glob(File.join(File.dirname(__FILE__), App.template.to_s, 'sugarcube-repl/**/*.rb')).reverse.each do |file|
+      app.files.insert(insert_point, file)
+    end
+    Dir.glob(File.join(File.dirname(__FILE__), 'cocoa/sugarcube-repl/**/*.rb')).reverse.each do |file|
+      app.files.insert(insert_point, file)
+    end
+    Dir.glob(File.join(File.dirname(__FILE__), 'all/sugarcube-repl/**/*.rb')).reverse.each do |file|
+      app.files.insert(insert_point, file)
+    end
   end
 end


### PR DESCRIPTION
I don't know if this will have any unintended consequences, but it seems that Kernel should only be monkeypatched while in development. The others ("test" and "release") should never need these methods defined on Kernel.
