### PR TITLE
Fix respond_to? to check original methods as well patches #156

### DIFF
--- a/lib/cocoa/sugarcube-anonymous/anonymous.rb
+++ b/lib/cocoa/sugarcube-anonymous/anonymous.rb
@@ -55,8 +55,9 @@ module SugarCube
       return super
     end
 
+    alias_method :hash_respond_to?, :respond_to?
     def respond_to?(method_name)
-      return true if self.include?(method_name)
+      return true if self.include?(method_name) or hash_respond_to?(method_name)
       false
     end
 


### PR DESCRIPTION
Allow respond_to? to work for normal hash methods on sugarcube-anonymous object.
