### PR TITLE
fix UIActionSheet undefined method `showFromBarButtonItem'

### DIFF
--- a/lib/ios/sugarcube-factories/uiactionsheet.rb
+++ b/lib/ios/sugarcube-factories/uiactionsheet.rb
@@ -122,7 +122,7 @@ class UIActionSheet
         view = UIApplication.sharedApplication.windows[0]
         alert.showFromRect(from, inView: view, animated: true)
       when UIBarButtonItem
-        alert.showFromBarButtonItem(from)
+        alert.showFromBarButtonItem(from, animated: true)
       when UIToolbar
         alert.showFromToolbar(from)
       when UITabBar


### PR DESCRIPTION
fix UIActionSheet undefined method `showFromBarButtonItem'
